### PR TITLE
feat: DVK-127 valvonta cdk

### DIFF
--- a/cdk/bin/dvk.ts
+++ b/cdk/bin/dvk.ts
@@ -13,7 +13,15 @@ import { PipelineMessaging } from '../lib/pipeline-messaging';
 import { SquatSite } from '../lib/squat-site';
 import { SquatPipeline } from '../lib/squat-pipeline';
 import { BackupServices } from '../lib/dvk-backup-services';
+import { MonitoringServices } from '../lib/dvk-monitoring';
 
+class DvkMonitoringServicesStack extends cdk.Stack {
+  constructor(parent: App, id: string, props: StackProps) {
+    super(parent, id, props);
+
+    new MonitoringServices(this, 'DvkMonitoringServices');
+  }
+}
 class DvkBackupServicesStack extends cdk.Stack {
   constructor(parent: App, id: string, props: StackProps) {
     super(parent, id, props);
@@ -161,5 +169,14 @@ new DvkBackupServicesStack(app, 'DvkBackupServicesStack', {
     region: process.env.CDK_DEFAULT_REGION,
   },
   stackName: 'DvkBackupServicesStack-' + appEnv,
+  tags: Config.tags,
+});
+
+new DvkMonitoringServicesStack(app, 'DvkMonitoringStack', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+  stackName: 'DvkMonitoringServicesStack-' + appEnv,
   tags: Config.tags,
 });

--- a/cdk/lib/dvk-monitoring.ts
+++ b/cdk/lib/dvk-monitoring.ts
@@ -1,27 +1,77 @@
 import { Construct } from 'constructs';
 import { FilterPattern, LogGroup, MetricFilter } from 'aws-cdk-lib/aws-logs';
-import { Alarm, ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
+import { Alarm, ComparisonOperator, Metric, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
+import lambdaFunctions from './lambda/graphql/lambdaFunctions';
+import lambda from 'aws-cdk-lib/aws-lambda';
+import { Duration, aws_cloudwatch as cloudwatch } from 'aws-cdk-lib';
+import { Subscription, SubscriptionProtocol, Topic } from 'aws-cdk-lib/aws-sns';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 
+declare const alias: lambda.Alias;
 export class MonitoringServices extends Construct {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, env: string) {
     super(scope, id);
-    console.log('placeholder');
-    //TODO: create log group filters
-    //TODO: create alarms for filters
-    //TODO: create alarms for lambdas, cloudfront and appsync
+    // create topic and subscription for alarms
+    const topic = new Topic(this, 'DvkAlarmsTopic', {
+      topicName: `DvkAlarmsTopic_${env}`,
+    });
+    const subscription = new Subscription(this, 'DvkAlarmSubscription', {
+      topic,
+      endpoint: 'juhani.kettunen@cgi.com',
+      protocol: SubscriptionProtocol.EMAIL,
+    });
 
-    //TODO: create cloudwatch dashboard
-    //TODO: create lambda widgets
+    // create log group filters for lambda logs and create alarms for filters
+    for (const lambdaFunc of lambdaFunctions) {
+      const functionName = `${lambdaFunc.typeName}-${lambdaFunc.fieldName}-${env}`.toLocaleLowerCase();
+      const metricFilter = this.createLogGroupMetricFilter(functionName, env);
+      this.createAlarmForMetric(metricFilter.metric(), env);
+    }
+
+    //TODO: create general alarms for lambdas...
+    const lambdaAlarms = this.createAlarmForMetric(alias.metricErrors(), env);
+    lambdaAlarms.addAlarmAction(new SnsAction(topic)); //TODO
+
+    // ...cloudfront
+    const cloudFrontMetric = new Metric({
+      namespace: 'AWS/CloudFront',
+      metricName: '5xxErrorRate',
+      dimensionsMap: { DistributionId: 'E2GP14WC00IGAB', Region: 'Global' }, //TODO: get distribution id
+      statistic: 'Max',
+      period: Duration.seconds(60),
+    });
+
+    const cloudFrontAlarm = this.createAlarmForMetric(cloudFrontMetric, env);
+    cloudFrontAlarm.addAlarmAction(new SnsAction(topic)); // TODO
+
+    // ... and appsync
+    // TODO
+
+    // dashboard
+    const dashboard = new cloudwatch.Dashboard(this, 'DvkDashboard', {
+      dashboardName: 'DvkDashboard' + env,
+      end: 'end',
+      periodOverride: cloudwatch.PeriodOverride.AUTO,
+      start: 'start',
+    });
     //TODO: create cloudfront widgets
-    //TODO: create appsync widgets
+    dashboard.addWidgets();
     //TODO: create error log widget
+    dashboard.addWidgets();
+    //TODO: create lambda widget
+    // This was supposed to be a an explorer type widget, but it is not supported by cdk yet ->
+    // have to collect all lambdas programatically
+    // errors, invocations, duration
+    dashboard.addWidgets();
+    //TODO: create appsync widgets
+    dashboard.addWidgets();
   }
 
-  createLogGroupMetricFilter(lambdaName: string): MetricFilter {
-    const filterPattern = FilterPattern.anyTerm('{($.level = "error") || ($.level = "fatal")}');
+  createLogGroupMetricFilter(lambdaName: string, env: string): MetricFilter {
+    const filterPattern = FilterPattern.any(FilterPattern.stringValue('$.level', '=', 'error'), FilterPattern.stringValue('$.level', '=', 'fatal'));
     const logGroupName = '/aws/lambda/' + lambdaName;
-    const metricName = lambdaName + '-metric';
-    const logGroup = LogGroup.fromLogGroupName(this, 'DvkLogGroup-' + lambdaName, logGroupName);
+    const metricName = lambdaName + `_metric_${env}`;
+    const logGroup = LogGroup.fromLogGroupName(this, 'DvkLogGroup_' + lambdaName, logGroupName);
     const metricFilter = new MetricFilter(this, 'MetricFilter', {
       logGroup,
       metricNamespace: 'DVK',
@@ -33,14 +83,30 @@ export class MonitoringServices extends Construct {
     return metricFilter;
   }
 
-  createAlarmForMetric(metric: Metric) {
+  createAlarmForMetric(metric: Metric, env: string) {
     const alarm = new Alarm(this, 'DvkErrors-' + metric.metricName, {
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       threshold: 1,
+      datapointsToAlarm: 1,
       evaluationPeriods: 1,
       metric,
+      alarmName: 'Dvk_' + metric.metricName + `_alarm_${env}`,
+      actionsEnabled: true,
+      treatMissingData: TreatMissingData.MISSING,
     });
 
     return alarm;
+  }
+
+  createCloudFrontWidget(env: string, metricName: string, statistic: string) {
+    // TODO
+  }
+
+  createLambdaWidget(env: string, metricName: string, statistic: string) {
+    // TODO
+  }
+
+  createAppSyncWidget(env: string, metricName: string, statistic: string) {
+    // TODO
   }
 }

--- a/cdk/lib/dvk-monitoring.ts
+++ b/cdk/lib/dvk-monitoring.ts
@@ -1,51 +1,51 @@
 import { Construct } from 'constructs';
 import { FilterPattern, LogGroup, MetricFilter } from 'aws-cdk-lib/aws-logs';
-import { Alarm, ComparisonOperator, Metric, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
+import { Alarm, ComparisonOperator, GraphWidget, Metric, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
 import lambdaFunctions from './lambda/graphql/lambdaFunctions';
-import lambda from 'aws-cdk-lib/aws-lambda';
 import { Duration, aws_cloudwatch as cloudwatch } from 'aws-cdk-lib';
 import { Subscription, SubscriptionProtocol, Topic } from 'aws-cdk-lib/aws-sns';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
+import Config from './config';
 
-declare const alias: lambda.Alias;
+type DvkMetric = { name: string; statistics: string };
 export class MonitoringServices extends Construct {
-  constructor(scope: Construct, id: string, env: string) {
+  constructor(scope: Construct, id: string) {
     super(scope, id);
+    const env = Config.getEnvironment();
+
     // create topic and subscription for alarms
     const topic = new Topic(this, 'DvkAlarmsTopic', {
       topicName: `DvkAlarmsTopic_${env}`,
     });
-    const subscription = new Subscription(this, 'DvkAlarmSubscription', {
+
+    new Subscription(this, 'DvkAlarmSubscription', {
       topic,
-      endpoint: 'juhani.kettunen@cgi.com',
+      endpoint: 'juhani.kettunen@cgi.com', //TODO: change to support email
       protocol: SubscriptionProtocol.EMAIL,
     });
+    const action = new SnsAction(topic);
 
     // create log group filters for lambda logs and create alarms for filters
     for (const lambdaFunc of lambdaFunctions) {
-      const functionName = `${lambdaFunc.typeName}-${lambdaFunc.fieldName}-${env}`.toLocaleLowerCase();
+      const functionName = this.getLambdaName(lambdaFunc.typeName, lambdaFunc.fieldName, env);
       const metricFilter = this.createLogGroupMetricFilter(functionName, env);
-      this.createAlarmForMetric(metricFilter.metric(), env);
+      const logAlarm = this.createAlarmForMetric(metricFilter.metric(), env);
+      logAlarm.addAlarmAction(action);
     }
 
-    //TODO: create general alarms for lambdas...
-    const lambdaAlarms = this.createAlarmForMetric(alias.metricErrors(), env);
-    lambdaAlarms.addAlarmAction(new SnsAction(topic)); //TODO
+    // create general alarms for lambdas...
+    const lambdaAlarms = this.createAlarmForMetric(this.createLambdaMetric(env, 'Errors', 'Sum'), env);
+    lambdaAlarms.addAlarmAction(action);
 
     // ...cloudfront
-    const cloudFrontMetric = new Metric({
-      namespace: 'AWS/CloudFront',
-      metricName: '5xxErrorRate',
-      dimensionsMap: { DistributionId: 'E2GP14WC00IGAB', Region: 'Global' }, //TODO: get distribution id
-      statistic: 'Max',
-      period: Duration.seconds(60),
-    });
-
-    const cloudFrontAlarm = this.createAlarmForMetric(cloudFrontMetric, env);
-    cloudFrontAlarm.addAlarmAction(new SnsAction(topic)); // TODO
+    // TODO: Cannot create an Alarm in region 'eu-west-1' based on metric '5xxErrorRate' in 'us-east-1'
+    // needs own stack with us-east-1 if no other workarounds
+    // const cloudFrontAlarm = this.createAlarmForMetric(this.createCloudFrontMetric(env, '5xxErrorRate', 'Max'), env);
+    // cloudFrontAlarm.addAlarmAction(action);
 
     // ... and appsync
-    // TODO
+    const appSyncAlarm = this.createAlarmForMetric(this.createAppSyncMetric(env, '5xxErrorRate', 'Max'), env);
+    appSyncAlarm.addAlarmAction(action);
 
     // dashboard
     const dashboard = new cloudwatch.Dashboard(this, 'DvkDashboard', {
@@ -54,17 +54,55 @@ export class MonitoringServices extends Construct {
       periodOverride: cloudwatch.PeriodOverride.AUTO,
       start: 'start',
     });
-    //TODO: create cloudfront widgets
-    dashboard.addWidgets();
-    //TODO: create error log widget
-    dashboard.addWidgets();
-    //TODO: create lambda widget
-    // This was supposed to be a an explorer type widget, but it is not supported by cdk yet ->
-    // have to collect all lambdas programatically
-    // errors, invocations, duration
-    dashboard.addWidgets();
-    //TODO: create appsync widgets
-    dashboard.addWidgets();
+    // create cloudfront widgets
+    const cwMetrics: DvkMetric[] = [
+      { name: 'Requests', statistics: 'Sum' },
+      { name: 'BytesDownloaded', statistics: 'Sum' },
+      { name: '4xxErrorRate', statistics: 'Sum' },
+      { name: '5xxErrorRate', statistics: 'Sum' },
+    ];
+    const cwWidgets = cwMetrics.map((metric) => this.createCloudFrontWidget(env, metric.name, metric.statistics));
+    dashboard.addWidgets(...cwWidgets);
+
+    // create error log widget
+    const logGroupNames = lambdaFunctions.map((lambda) => `/aws/lambda/${this.getLambdaName(lambda.typeName, lambda.fieldName, env)}`);
+
+    dashboard.addWidgets(
+      new cloudwatch.LogQueryWidget({
+        logGroupNames: logGroupNames,
+        view: cloudwatch.LogQueryVisualizationType.TABLE,
+        // The lines will be automatically combined using '\n|'.
+        queryLines: [
+          'fields @timestamp, @message',
+          'filter @message like /ERROR/ or level like /error/ or level like /fatal/',
+          'sort @timestamp desc',
+          'limit 50',
+        ],
+      })
+    );
+
+    // create lambda widget
+    // TODO: Might change to an explorer type widget with tag selection (project: dvk, env: prod), when supported by cdk
+    const lambdaMetrics: DvkMetric[] = [
+      { name: 'Invocations', statistics: 'Sum' },
+      { name: 'Errors', statistics: 'Sum' },
+      { name: 'Duration', statistics: 'Sum' },
+    ];
+    const lambdaWidgets = lambdaMetrics.map((metric) => this.createLambdaWidget(env, metric.name, metric.statistics));
+    dashboard.addWidgets(...lambdaWidgets);
+
+    // create appsync widgets
+    const appsyncMetrics: DvkMetric[] = [
+      // { name: 'Requests', statistics: 'Sample count' }, // throws error, which might be a cdk bug: "dataPath": "/widgets/8/properties/metrics/0", "message": "Should NOT have more than 4 items"
+      { name: '4xxErrorRate', statistics: 'Sum' },
+      { name: '5xxErrorRate', statistics: 'Sum' },
+    ];
+    const appsyncWidgets = appsyncMetrics.map((metric) => this.createAppSyncWidget(env, metric.name, metric.statistics));
+    dashboard.addWidgets(...appsyncWidgets);
+  }
+
+  getLambdaName(typeName: string, fieldName: string, env: string) {
+    return `${typeName}-${fieldName}-${env}`.toLocaleLowerCase();
   }
 
   createLogGroupMetricFilter(lambdaName: string, env: string): MetricFilter {
@@ -72,7 +110,7 @@ export class MonitoringServices extends Construct {
     const logGroupName = '/aws/lambda/' + lambdaName;
     const metricName = lambdaName + `_metric_${env}`;
     const logGroup = LogGroup.fromLogGroupName(this, 'DvkLogGroup_' + lambdaName, logGroupName);
-    const metricFilter = new MetricFilter(this, 'MetricFilter', {
+    const metricFilter = new MetricFilter(this, `MetricFilter_${lambdaName}`, {
       logGroup,
       metricNamespace: 'DVK',
       metricName,
@@ -90,7 +128,7 @@ export class MonitoringServices extends Construct {
       datapointsToAlarm: 1,
       evaluationPeriods: 1,
       metric,
-      alarmName: 'Dvk_' + metric.metricName + `_alarm_${env}`,
+      alarmName: 'Dvk_' + metric.namespace.split('/').pop() + metric.metricName + `_alarm_${env}`,
       actionsEnabled: true,
       treatMissingData: TreatMissingData.MISSING,
     });
@@ -98,15 +136,66 @@ export class MonitoringServices extends Construct {
     return alarm;
   }
 
-  createCloudFrontWidget(env: string, metricName: string, statistic: string) {
-    // TODO
+  createCloudFrontMetric(env: string, metricName: string, statistic: string) {
+    const metric = new Metric({
+      namespace: 'AWS/CloudFront',
+      metricName: metricName,
+      dimensionsMap: { DistributionId: 'E2GP14WC00IGAB', Region: 'Global' }, //TODO: get distribution id from stack outputs
+      statistic: statistic,
+      period: Duration.seconds(300),
+      region: 'us-east-1',
+    });
+
+    return metric;
+  }
+
+  createCloudFrontWidget(env: string, metricName: string, statistic: string): GraphWidget {
+    const metric = this.createCloudFrontMetric(env, metricName, statistic);
+
+    return new GraphWidget({
+      title: `CF ${metricName} ${env}`,
+      left: [metric],
+    });
+  }
+
+  createLambdaMetric(env: string, metricName: string, statistic: string) {
+    const metric = new Metric({
+      namespace: 'AWS/Lambda',
+      metricName: metricName,
+      statistic: statistic,
+      period: Duration.seconds(300),
+    });
+
+    return metric;
   }
 
   createLambdaWidget(env: string, metricName: string, statistic: string) {
-    // TODO
+    const metric = this.createLambdaMetric(env, metricName, statistic);
+
+    return new GraphWidget({
+      title: `Lambda ${metricName} ${env}`,
+      left: [metric],
+    });
+  }
+
+  createAppSyncMetric(env: string, metricName: string, statistic: string) {
+    const metric = new Metric({
+      namespace: 'AWS/AppSync',
+      metricName: metricName,
+      dimensionsMap: { GraphQLAPIId: 'dw2qzecu7jglvhofutllu7hal4' }, //TODO get id from stack outputs or smth
+      statistic: statistic,
+      period: Duration.seconds(300),
+    });
+
+    return metric;
   }
 
   createAppSyncWidget(env: string, metricName: string, statistic: string) {
-    // TODO
+    const metric = this.createAppSyncMetric(env, metricName, statistic);
+
+    return new GraphWidget({
+      title: `AppSync ${metricName} ${env}`,
+      left: [metric],
+    });
   }
 }

--- a/cdk/lib/dvk-monitoring.ts
+++ b/cdk/lib/dvk-monitoring.ts
@@ -1,0 +1,46 @@
+import { Construct } from 'constructs';
+import { FilterPattern, LogGroup, MetricFilter } from 'aws-cdk-lib/aws-logs';
+import { Alarm, ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
+
+export class MonitoringServices extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    console.log('placeholder');
+    //TODO: create log group filters
+    //TODO: create alarms for filters
+    //TODO: create alarms for lambdas, cloudfront and appsync
+
+    //TODO: create cloudwatch dashboard
+    //TODO: create lambda widgets
+    //TODO: create cloudfront widgets
+    //TODO: create appsync widgets
+    //TODO: create error log widget
+  }
+
+  createLogGroupMetricFilter(lambdaName: string): MetricFilter {
+    const filterPattern = FilterPattern.anyTerm('{($.level = "error") || ($.level = "fatal")}');
+    const logGroupName = '/aws/lambda/' + lambdaName;
+    const metricName = lambdaName + '-metric';
+    const logGroup = LogGroup.fromLogGroupName(this, 'DvkLogGroup-' + lambdaName, logGroupName);
+    const metricFilter = new MetricFilter(this, 'MetricFilter', {
+      logGroup,
+      metricNamespace: 'DVK',
+      metricName,
+      filterPattern,
+      metricValue: '1',
+      defaultValue: 0,
+    });
+    return metricFilter;
+  }
+
+  createAlarmForMetric(metric: Metric) {
+    const alarm = new Alarm(this, 'DvkErrors-' + metric.metricName, {
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric,
+    });
+
+    return alarm;
+  }
+}


### PR DESCRIPTION
Hieman kesken, mutta saa aikaan jo pääosan cloudwatch dashboardin widgeteistä, sekä hälytyksistä.

Lopullisessa ratkaisussa ainakin cloudfront ja appsync id:t haetaan automaattisesti, sekä cloudwatch -hälytys luodaan omana stackinaan tms, eri regioonalle.