### PR TITLE
DVK-1052 cicd build image with fixed npm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/docker/library/node:18.16.0-alpine
 ENV WORK /opt/dvk
 WORKDIR ${WORK}
 RUN mkdir -p ${WORK}
-RUN npm install -g npm@latest
+RUN npm install -g npm@9
 RUN apk add --no-cache \
         bash \
         python3 \

--- a/cdk/lib/dvk-build-image-stack.ts
+++ b/cdk/lib/dvk-build-image-stack.ts
@@ -43,7 +43,7 @@ export class DvkBuildImageStack extends Stack {
       actions: [sourceAction],
     });
     const account = cdk.Stack.of(this).account;
-    const buildProject = this.buildProject(account, imageRepoName, '1.0.4', '.', 'ImageBuild');
+    const buildProject = this.buildProject(account, imageRepoName, '1.0.5', '.', 'ImageBuild');
     const actions: IAction[] = [];
     actions.push(
       new cdk.aws_codepipeline_actions.CodeBuildAction({


### PR DESCRIPTION
* set npm version to 9 for compatibility with base image node (npm@latest installs v10)