### PR TITLE
feat: DVK-1041 statistics

### DIFF
--- a/cdk/bin/dvk.ts
+++ b/cdk/bin/dvk.ts
@@ -17,6 +17,7 @@ import { MonitoringServices } from '../lib/dvk-monitoring';
 import { DvkUsEast } from '../lib/dvk-us-east';
 import { AdminPipeline } from '../lib/admin-pipeline';
 import { DvkScheduledTestsPipelineStack } from '../lib/dvk-scheduled-tests-pipeline';
+import { DvkAnalyticsStack } from '../lib/dvk-analytics-stack';
 
 class DvkUsEastStack extends cdk.Stack {
   constructor(parent: App, id: string, props: StackProps) {
@@ -198,6 +199,20 @@ new DvkMonitoringServicesStack(app, 'DvkMonitoringStack', {
   stackName: 'DvkMonitoringServicesStack-' + appEnv,
   tags: Config.tags,
 });
+
+new DvkAnalyticsStack(
+  app,
+  'DvkAnalyticsStack',
+  {
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION,
+    },
+    stackName: 'DvkAnalyticsStack-' + appEnv,
+    tags: Config.tags,
+  },
+  appEnv
+);
 
 new DvkUsEastStack(app, 'DvkUsEastStack', {
   env: {

--- a/cdk/fargate/Dockerfile
+++ b/cdk/fargate/Dockerfile
@@ -1,0 +1,20 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+
+RUN yum -y update && \
+    yum -y install tar && \
+    yum -y install gzip && \
+    yum -y install awscli && \
+    yum -y install gcc automake autoconf make ncurses-devel zlib-devel && \
+    yum -y clean all
+
+RUN curl -o goaccess-1.8.tar.gz https://tar.goaccess.io/goaccess-1.8.tar.gz && \
+    tar -xzvf goaccess-1.8.tar.gz && \
+    cd goaccess-1.8/ && \
+    ./configure --enable-utf8 && \
+    make && \
+    make install
+
+ADD analyze.sh /analyze.sh
+RUN chmod +x /analyze.sh
+
+CMD ["/analyze.sh"]

--- a/cdk/fargate/analyze.sh
+++ b/cdk/fargate/analyze.sh
@@ -35,19 +35,20 @@ else
 fi
 
 #TODO: Upload report to S3
+month_number=$(date +'%m')
 #if environment variable REPORT_BUCKET exists
 if [ -z "$REPORT_BUCKET" ]; then
     echo "REPORT_BUCKET environment variable is not set. Skipping report upload."
     exit 0
 else
     echo "Uploading report to S3"
-    aws s3 cp report.html s3://$REPORT_BUCKET/
+    aws s3 cp report.html s3://$REPORT_BUCKET/reports/$month_number/
     if [ $? -ne 0 ]; then
         echo "Error uploading report"
         exit 1
     else
         echo "Report uploaded"
-        echo "Report URL: https://$REPORT_BUCKET.s3.amazonaws.com/report.html"
+        echo "Report URL: https://$REPORT_BUCKET.s3.amazonaws.com/reports/$month_number/report.html"
         exit 0
     fi
 fi

--- a/cdk/fargate/analyze.sh
+++ b/cdk/fargate/analyze.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+if [ -z "$LOG_BUCKET" ]; then
+    echo "LOG_BUCKET environment variable is not set. Please set it before running this script."
+    exit 1
+fi
+
+if [ -z "$CF_DISTRIBUTION" ]; then
+    echo "CF_DISTRIBUTION environment variable is not set. Please set it before running this script."
+    exit 1
+fi
+
+#Log filenames start with distribution id.year.month eg. E2GP14WC00IGAB.2023-11-
+s3_prefix="$CF_DISTRIBUTION.$(date +'%Y-%m')-*"
+
+mkdir cflogs
+
+echo "aws s3 cp "s3://$LOG_BUCKET" cflogs/ --exclude "*" --include $s3_prefix --recursive"
+aws s3 cp "s3://$LOG_BUCKET" cflogs/ --exclude "*" --include $s3_prefix --recursive
+
+if [ $? -ne 0 ]; then
+    echo "Could not download files from s3"
+    exit 1
+else
+    echo "File download ready"
+fi
+
+echo "Creating report"
+gunzip -c cflogs/*.gz | goaccess -a -o report.html --time-format=%H:%M:%S --date-format=%Y-%m-%d --log-format=CLOUDFRONT -
+if [ $? -ne 0 ]; then
+    echo "Error creating report"
+    exit 1
+else
+    echo "Report ready"
+fi
+
+#TODO: Upload report to S3
+#if environment variable REPORT_BUCKET exists
+if [ -z "$REPORT_BUCKET" ]; then
+    echo "REPORT_BUCKET environment variable is not set. Skipping report upload."
+    exit 0
+else
+    echo "Uploading report to S3"
+    aws s3 cp report.html s3://$REPORT_BUCKET/
+    if [ $? -ne 0 ]; then
+        echo "Error uploading report"
+        exit 1
+    else
+        echo "Report uploaded"
+        echo "Report URL: https://$REPORT_BUCKET.s3.amazonaws.com/report.html"
+        exit 0
+    fi
+fi

--- a/cdk/fargate/analyze.sh
+++ b/cdk/fargate/analyze.sh
@@ -34,7 +34,7 @@ else
     echo "Report ready"
 fi
 
-#TODO: Upload report to S3
+year_number=$(date +'%Y')
 month_number=$(date +'%m')
 #if environment variable REPORT_BUCKET exists
 if [ -z "$REPORT_BUCKET" ]; then
@@ -42,13 +42,13 @@ if [ -z "$REPORT_BUCKET" ]; then
     exit 0
 else
     echo "Uploading report to S3"
-    aws s3 cp report.html s3://$REPORT_BUCKET/reports/$month_number/
+    aws s3 cp report.html s3://$REPORT_BUCKET/reports/$year_number/$month_number/
     if [ $? -ne 0 ]; then
         echo "Error uploading report"
         exit 1
     else
         echo "Report uploaded"
-        echo "Report URL: https://$REPORT_BUCKET.s3.amazonaws.com/reports/$month_number/report.html"
+        echo "Report URL: https://$REPORT_BUCKET.s3.amazonaws.com/reports/$year_number/$month_number/report.html"
         exit 0
     fi
 fi

--- a/cdk/lib/dvk-analytics-stack.ts
+++ b/cdk/lib/dvk-analytics-stack.ts
@@ -1,55 +1,121 @@
 // Import AWS CDK libraries
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import * as events from 'aws-cdk-lib/aws-events';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
-import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cdk from 'aws-cdk-lib';
+import { Repository } from 'aws-cdk-lib/aws-ecr';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 
 export class DvkAnalyticsStack extends Stack {
-  constructor(scope: Construct, id: string, env: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props: StackProps, env: string) {
     super(scope, id, props);
 
-    const importedLogBucket = cdk.Fn.importValue('AccessLogBucket' + env); //DistributionId
+    const importedLogBucket = cdk.Fn.importValue('AccessLogBucket' + env);
     const importedDistributionId = cdk.Fn.importValue('SquatDistribution' + env);
 
+    // create report bucket for dvk-analytics
+    const reportBucket = new s3.Bucket(this, 'DvkAnalyticsReportBucket', {
+      bucketName: 'dvk-analytics-report-' + env,
+      publicReadAccess: false,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: BucketEncryption.S3_MANAGED,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const vpc = Vpc.fromLookup(this, 'DvkVPC', { vpcName: this.getVPCName(env) });
+    const ecsSecurityGroup = new ec2.SecurityGroup(this, 'ECSSecurityGroup', {
+      vpc,
+      allowAllOutbound: true,
+    });
+
     // Define an IAM role for the Fargate task
-    const taskRole = new iam.Role(this, 'DvkFargateTaskRole', {
+    const taskRole = new iam.Role(this, 'DvkFargateTaskRole' + env, {
       assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
     });
 
+    // Get s3 instance of importedLogBucket
+    const logBucketS3 = s3.Bucket.fromBucketName(this, 'DvkCloudFrontLogBucket', importedLogBucket);
+
     // Add permissions to access the S3 bucket
+    logBucketS3.addToResourcePolicy(
+      new iam.PolicyStatement({
+        actions: ['s3:GetObject', 's3:ListBucket', 's3:ListObjectsV2'],
+        resources: [logBucketS3.arnForObjects('*')],
+        principals: [taskRole.grantPrincipal],
+      })
+    );
+
     taskRole.addToPolicy(
       new iam.PolicyStatement({
-        actions: ['s3:GetObject', 's3:ListBucket'],
+        actions: ['s3:GetObject', 's3:ListBucket', 's3:ListObjectsV2'],
         resources: [`arn:aws:s3:::${importedLogBucket}/*`],
       })
     );
 
+    const cluster = new ecs.Cluster(this, 'ECSCluster', {
+      vpc: vpc,
+    });
+
     // Define the Fargate task definition
-    const taskDefinition = new ecs.FargateTaskDefinition(this, 'DvkFargateTask', {
+    const taskDefinition = new ecs.FargateTaskDefinition(this, 'DvkFargateTask' + env, {
       memoryLimitMiB: 1024,
       cpu: 512,
       taskRole,
     });
 
+    // Degine log group for the Fargate task definition
+    const logGroup = new logs.LogGroup(this, 'LogGroup', {
+      logGroupName: '/ecs/dvk-analytics',
+      retention: logs.RetentionDays.TWO_WEEKS,
+    });
+
     // Define your container image and task definition details
-    taskDefinition.addContainer('DvkAnalyticsContainer', {
-      image: ecs.ContainerImage.fromRegistry('dvk-image-repo/your-image:latest'), //TODO: image
+    taskDefinition.addContainer('DvkAnalyticsContainer' + env, {
+      image: ecs.ContainerImage.fromEcrRepository(Repository.fromRepositoryName(this, 'DvkAnalyticsImage', 'dvk-analyticsimage'), '1.0.1'),
       environment: {
+        REPORT_BUCKET: reportBucket.bucketName,
         LOG_BUCKET: importedLogBucket,
         CF_DISTRIBUTION: importedDistributionId,
       },
+      logging: ecs.LogDrivers.awsLogs({
+        logGroup: logGroup,
+        streamPrefix: 'AnalyticsContainer',
+      }),
     });
 
     // Define the ECS service
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const fargateService = new ecsPatterns.ScheduledFargateTask(this, 'DvkFargateScheduler', {
-      scheduledFargateTaskDefinitionOptions: {
-        taskDefinition,
-      },
-      schedule: events.Schedule.cron({ minute: '0', hour: '0' }), // Daily at midnight
+    const fargateService = new ecs.FargateService(this, 'DvkFargateScheduled' + env, {
+      cluster,
+      taskDefinition,
+      securityGroups: [ecsSecurityGroup],
     });
+
+    // // Define the rule for scheduling the Fargate task
+    // const rule = new events.Rule(this, 'DvkAnalyticsScheduledRule', {
+    //   schedule: events.Schedule.cron({ minute: '0', hour: '0' }), // Daily at midnight
+    // });
+
+    // rule.addTarget(
+    //   new targets.EcsTask({
+    //     cluster: cluster,
+    //     taskDefinition,
+    //   })
+    // );
+  }
+
+  private getVPCName(env: string): string {
+    if (env === 'test') {
+      return 'DvkTest-VPC';
+    } else if (env === 'prod') {
+      return 'DVKProd-VPC';
+    } else {
+      return 'DvkDev-VPC';
+    }
   }
 }

--- a/cdk/lib/dvk-analytics-stack.ts
+++ b/cdk/lib/dvk-analytics-stack.ts
@@ -1,0 +1,52 @@
+// Import AWS CDK libraries
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+export class DvkAnalyticsStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    // Define an IAM role for the Fargate task
+    const taskRole = new iam.Role(this, 'DvkFargateTaskRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+    });
+
+    // Add permissions to access the S3 bucket
+    taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['s3:GetObject', 's3:ListBucket'],
+        resources: ['arn:aws:s3:::log-s3-bucket-name/*'], // TODO: S3 bucket
+      })
+    );
+
+    // Define the Fargate task definition
+    const taskDefinition = new ecs.FargateTaskDefinition(this, 'DvkFargateTask', {
+      memoryLimitMiB: 1024,
+      cpu: 512,
+      taskRole,
+    });
+
+    // Define your container image and task definition details
+    taskDefinition.addContainer('DvkAnalyticsContainer', {
+      image: ecs.ContainerImage.fromRegistry('dvk-image-repo/your-image:latest'), //TODO: image
+      environment: {
+        //TODO: env vars
+        LOG_BUCKET: 'cloudfront-dvk-dev',
+        CF_DISTRIBUTION: 'E2GP14WC00IGAB',
+      },
+    });
+
+    // Define the ECS service
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const fargateService = new ecsPatterns.ScheduledFargateTask(this, 'DvkFargateScheduler', {
+      scheduledFargateTaskDefinitionOptions: {
+        taskDefinition,
+      },
+      schedule: events.Schedule.cron({ minute: '0', hour: '0' }), // Daily at midnight
+    });
+  }
+}

--- a/cdk/lib/dvk-build-image-stack.ts
+++ b/cdk/lib/dvk-build-image-stack.ts
@@ -34,7 +34,7 @@ export class DvkBuildImageStack extends Stack {
       repo: 'dvk',
       oauthToken: SecretValue.secretsManager('dev/dvk/github'),
       output: sourceOutput,
-      branch: env === 'prod' ? 'prod' : 'feature/DVK-1041-statistics',
+      branch: env === 'prod' ? 'prod' : 'main',
       trigger: GitHubTrigger.NONE,
     });
 

--- a/cdk/lib/dvk-build-image-stack.ts
+++ b/cdk/lib/dvk-build-image-stack.ts
@@ -34,7 +34,7 @@ export class DvkBuildImageStack extends Stack {
       repo: 'dvk',
       oauthToken: SecretValue.secretsManager('dev/dvk/github'),
       output: sourceOutput,
-      branch: env === 'prod' ? 'prod' : 'DVK-1041-statistics',
+      branch: env === 'prod' ? 'prod' : 'feature/DVK-1041-statistics',
       trigger: GitHubTrigger.NONE,
     });
 

--- a/cdk/lib/dvk-build-image-stack.ts
+++ b/cdk/lib/dvk-build-image-stack.ts
@@ -34,7 +34,7 @@ export class DvkBuildImageStack extends Stack {
       repo: 'dvk',
       oauthToken: SecretValue.secretsManager('dev/dvk/github'),
       output: sourceOutput,
-      branch: env === 'prod' ? 'prod' : 'main',
+      branch: env === 'prod' ? 'prod' : 'DVK-1041-statistics',
       trigger: GitHubTrigger.NONE,
     });
 
@@ -72,6 +72,28 @@ export class DvkBuildImageStack extends Stack {
         input: sourceOutput,
       })
     );
+
+    const analyticsImageRepoName = 'dvk-analyticsimage';
+    new cdk.aws_ecr.Repository(this, 'AnalyticsBuildImageRepository', {
+      repositoryName: analyticsImageRepoName,
+      lifecycleRules: [
+        {
+          rulePriority: 1,
+          description: 'Remove untagged images over 30 days old',
+          maxImageAge: cdk.Duration.days(30),
+          tagStatus: TagStatus.UNTAGGED,
+        },
+      ],
+    });
+    const analyticsBuildProject = this.buildProject(account, analyticsImageRepoName, '1.0.1', 'cdk/fargate', 'AnalyticsImageBuild');
+    actions.push(
+      new cdk.aws_codepipeline_actions.CodeBuildAction({
+        actionName: 'BuildAnalyticsImage',
+        project: analyticsBuildProject,
+        input: sourceOutput,
+      })
+    );
+
     pipeline.addStage({
       stageName: 'Build',
       actions,

--- a/cdk/lib/squat-site.ts
+++ b/cdk/lib/squat-site.ts
@@ -120,6 +120,22 @@ export class SquatSite extends Construct {
       description: 'The name of Admin app S3',
       exportName: 'AdminBucket' + props.env,
     });
+
+    // Accesss log bucket
+    const logBucket = new s3.Bucket(this, 'LogBucket', {
+      bucketName: `dvk-access-logs-${props.env}`,
+      publicReadAccess: false,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: BucketEncryption.S3_MANAGED,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+      ...s3DeletePolicy,
+    });
+    new CfnOutput(parent, 'AccessLogBucket', {
+      value: logBucket.bucketName,
+      description: 'The name of cloudfront access log bucket',
+      exportName: 'AccessLogBucket' + props.env,
+    });
+
     // TLS certificate
     let certificate, domainNames;
     if (props.cloudfrontCertificateArn) {
@@ -362,6 +378,8 @@ export class SquatSite extends Construct {
         { httpStatus: 404, responseHttpStatus: 404, responsePagePath: '/notfound.html' },
         { httpStatus: 500, responseHttpStatus: 500, responsePagePath: '/error.html' },
       ],
+      enableLogging: true,
+      logBucket: logBucket,
     });
 
     new CfnOutput(parent, 'DistributionId', {


### PR DESCRIPTION
Taskia ei saanut luotua automaattisesti ajastetuksi, se olisi vaatinut, että vpc:n subnetit olisivat olleet tiettyä tyyppiä. 

Sen sijaan, että nyt olisi lähdetty selvittämään väyläpilveltä, saako itse luoda subnettejä, cdk luo kaiken muun tarvittavan, mutta itse ajastus käydään tekemässä konsolissa - kertaluontoisesti.

Jos tuo cdk:n rajoitus tietyn tyyppisestä subnetistä muuttuu, tai selviää, että voidaan itse luoda sopiva, niin cdk koodiin voidaan tällöin lisätä myös ajastetun tehtävän luonti. 