### PR TITLE
feat: automatic backend deploy

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -30,7 +30,8 @@
         "jwk-to-pem": "2.0.5",
         "pino": "^8.16.2",
         "proj4": "^2.9.2",
-        "source-map-support": "^0.5.21"
+        "source-map-support": "^0.5.21",
+        "watch": "^1.0.2"
       },
       "bin": {
         "dvk": "bin/dvk.js"
@@ -8336,6 +8337,14 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dependencies": {
+        "merge": "^1.2.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -11083,6 +11092,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11187,7 +11201,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13527,6 +13540,21 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha512-1u+Z5n9Jc1E2c7qDO8SinPoZuHj7FgbgU1olSFoyaklduDvvtX7GMMtlE6OC9FTXq4KvNAOfj6Zu4vI1e9bAKA==",
+      "dependencies": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "watch": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.1.95"
       }
     },
     "node_modules/wcwidth": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "watch:backend": "watch 'npm run deploy:backend:hotswap' ./lib/lambda",
     "test": "cross-env LOG_LEVEL=silent TZ=UTC jest",
     "update:snapshot": "cross-env LOG_LEVEL=silent TZ=UTC jest --updateSnapshot",
     "cdk": "cdk",
@@ -92,7 +93,8 @@
     "jwk-to-pem": "2.0.5",
     "pino": "^8.16.2",
     "proj4": "^2.9.2",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "watch": "^1.0.2"
   },
   "engines": {
     "node": ">=18.16.0",


### PR DESCRIPTION
Installed watch and added script for detecting changes in cdk/lib/lambda folder, which should cover most of backend functions. 

Start and forget (let it run) ie in Visual Studio Code terminal, or separate shell window using command "npm run watch:backend". Shell should have the usual env variables set (ENVIRONMENT and AWS_PROFILE).

Edit a file, save changes and see it run "npm run deploy:backend:hotswap".
