### PR TITLE
DVK-1393 codepipeline version and mode

### DIFF
--- a/cdk/lib/admin-pipeline.ts
+++ b/cdk/lib/admin-pipeline.ts
@@ -20,6 +20,8 @@ export class AdminPipeline extends Construct {
 
     const pipeline = new codepipeline.Pipeline(this, 'AdminPipeline', {
       crossAccountKeys: false,
+      pipelineType: codepipeline.PipelineType.V1,
+      executionMode: codepipeline.ExecutionMode.SUPERSEDED,
     });
     const sourceOutput = new codepipeline.Artifact();
     const sourceAction = new cdk.aws_codepipeline_actions.GitHubSourceAction({

--- a/cdk/lib/dvk-build-image-stack.ts
+++ b/cdk/lib/dvk-build-image-stack.ts
@@ -26,6 +26,8 @@ export class DvkBuildImageStack extends Stack {
     });
     const pipeline = new codepipeline.Pipeline(this, 'BuildImagePipeline', {
       crossAccountKeys: false,
+      pipelineType: codepipeline.PipelineType.V1,
+      executionMode: codepipeline.ExecutionMode.SUPERSEDED,
     });
     const sourceOutput = new codepipeline.Artifact();
     const sourceAction = new cdk.aws_codepipeline_actions.GitHubSourceAction({

--- a/cdk/lib/dvk-pipeline.ts
+++ b/cdk/lib/dvk-pipeline.ts
@@ -23,6 +23,8 @@ export class DvkPipeline extends Construct {
 
     const pipeline = new codepipeline.Pipeline(this, 'DvkPipeline', {
       crossAccountKeys: false,
+      pipelineType: codepipeline.PipelineType.V1,
+      executionMode: codepipeline.ExecutionMode.SUPERSEDED,
     });
     const sourceOutput = new codepipeline.Artifact();
     const sourceAction = new cdk.aws_codepipeline_actions.GitHubSourceAction({

--- a/cdk/lib/preview-pipeline.ts
+++ b/cdk/lib/preview-pipeline.ts
@@ -20,6 +20,8 @@ export class PreviewPipeline extends Construct {
 
     const pipeline = new codepipeline.Pipeline(this, 'PreviewPipeline', {
       crossAccountKeys: false,
+      pipelineType: codepipeline.PipelineType.V1,
+      executionMode: codepipeline.ExecutionMode.SUPERSEDED,
     });
     const sourceOutput = new codepipeline.Artifact();
     const sourceAction = new cdk.aws_codepipeline_actions.GitHubSourceAction({

--- a/cdk/lib/squat-pipeline.ts
+++ b/cdk/lib/squat-pipeline.ts
@@ -20,6 +20,8 @@ export class SquatPipeline extends Construct {
 
     const pipeline = new codepipeline.Pipeline(this, 'SquatPipeline', {
       crossAccountKeys: false,
+      pipelineType: codepipeline.PipelineType.V1,
+      executionMode: codepipeline.ExecutionMode.SUPERSEDED,
     });
     const sourceOutput = new codepipeline.Artifact();
     const sourceAction = new cdk.aws_codepipeline_actions.GitHubSourceAction({


### PR DESCRIPTION
* set dvk pipelines to use v1 superseded mode
* DVK pipelines can use v1 and superseded mode, as v2 perhaps main difference is the different possible execution and wait modes that allow queueing (preserve order) or parallel execution (ie. isolated feature specific environments)
* might consider changing feature branch testing codebuild project to codepipeline v2  as it seems to support triggering & filtering for source

https://docs.aws.amazon.com/codepipeline/latest/userguide/pipeline-types-planning.html
https://docs.aws.amazon.com/codepipeline/latest/userguide/concepts-how-it-works.html