### PR TITLE
DVK-1690 : Fixed scroll problem in Chrome for 1 weather forecast table

### DIFF
--- a/src/components/ForecastTable.css
+++ b/src/components/ForecastTable.css
@@ -22,12 +22,20 @@
   border-bottom: 1px solid #cccccc;
 }
 
+.ForecastGrid .DateRow.hidden {
+  display: none;
+}
+
 .ForecastGrid .ForecastRow {
   border-bottom: 1px solid #cccccc;
 }
 
 .ForecastGrid .ForecastRow ion-col:not(:last-child) {
   border-right: 1px solid #cccccc;
+}
+
+.ForecastGrid .ForecastRow.hidden {
+  display: none;
 }
 
 .ForecastGrid .ForecastColGreen {

--- a/src/components/ForecastTable.tsx
+++ b/src/components/ForecastTable.tsx
@@ -8,11 +8,12 @@ type ForecastTableProps = {
   forecastItems: ForecastItem[];
   page?: number;
   clear?: boolean;
+  multitable?: boolean;
 };
 
 type ForecastRowProps = {
   forecastItem: ForecastItem;
-  visible: boolean;
+  visible?: boolean;
 };
 
 const timezoneOffsetMinutesToString = (date: Date) => {
@@ -28,7 +29,7 @@ const timezoneOffsetMinutesToString = (date: Date) => {
   }
 };
 
-const ForecastTableDateRow: React.FC<ForecastRowProps> = ({ forecastItem, visible }) => {
+const ForecastTableDateRow: React.FC<ForecastRowProps> = ({ forecastItem, visible = true }) => {
   const { t } = useTranslation();
 
   const hide: string = visible ? '' : ' hidden';
@@ -96,7 +97,7 @@ const ForecastTableRow: React.FC<ForecastRowProps> = ({ forecastItem, visible })
   );
 };
 
-const ForecastTable: React.FC<ForecastTableProps> = ({ forecastItems, page, clear = false }) => {
+const ForecastTable: React.FC<ForecastTableProps> = ({ forecastItems, page, clear = false, multitable = false }) => {
   const { t } = useTranslation();
   const [startIndex, setStartIndex] = useState<number>(0);
   const pageSize = page ?? 8;
@@ -119,6 +120,8 @@ const ForecastTable: React.FC<ForecastTableProps> = ({ forecastItems, page, clea
   };
 
   const gridClassName = 'ForecastGrid' + ((clear ? ' clear' : '') + ' ion-no-padding');
+  const forecastItemsToShow = multitable ? forecastItems.slice(startIndex, startIndex + pageSize) : forecastItems;
+
   return (
     <IonGrid className={gridClassName}>
       <IonRow className="HeaderRow ion-justify-content-between">
@@ -140,12 +143,14 @@ const ForecastTable: React.FC<ForecastTableProps> = ({ forecastItems, page, clea
           {t('forecastTable.tableHeaders.visibility')}
         </IonCol>
       </IonRow>
-      {forecastItems.length > 0 ? (
-        forecastItems.map((item, index, items) => {
-          const isOnThisPage = index >= startIndex && index < startIndex + pageSize;
+
+      {forecastItemsToShow.length > 0 ? (
+        forecastItemsToShow.map((item, index, items) => {
+          const isOnThisPage = multitable || (index >= startIndex && index < startIndex + pageSize);
           const showDateRow =
             isOnThisPage &&
-            ((index === startIndex && new Date(item.dateTime).getDate() === new Date(items[startIndex + pageSize - 1].dateTime).getDate()) ||
+            ((index === (multitable ? 0 : startIndex) &&
+              new Date(item.dateTime).getDate() === new Date(items[(multitable ? 0 : startIndex) + pageSize - 1].dateTime).getDate()) ||
               (index !== 0 && new Date(items[index].dateTime).getDate() !== new Date(items[index - 1].dateTime).getDate()));
           return (
             <div key={item.dateTime}>

--- a/src/components/ForecastTable.tsx
+++ b/src/components/ForecastTable.tsx
@@ -8,13 +8,11 @@ type ForecastTableProps = {
   forecastItems: ForecastItem[];
   page?: number;
   clear?: boolean;
-
-  //Remove this when a solution is found in future ticket to fix scroll problem
-  requiresScrolling?: boolean;
 };
 
 type ForecastRowProps = {
   forecastItem: ForecastItem;
+  visible: boolean;
 };
 
 const timezoneOffsetMinutesToString = (date: Date) => {
@@ -30,11 +28,12 @@ const timezoneOffsetMinutesToString = (date: Date) => {
   }
 };
 
-const ForecastTableDateRow: React.FC<ForecastRowProps> = ({ forecastItem }) => {
+const ForecastTableDateRow: React.FC<ForecastRowProps> = ({ forecastItem, visible }) => {
   const { t } = useTranslation();
 
+  const hide: string = visible ? '' : ' hidden';
   return (
-    <IonRow className="DateRow">
+    <IonRow className={'DateRow' + hide}>
       <IonCol size="12" className="ion-text-center">
         {t('forecastTable.dateRowFormat', { val: forecastItem.dateTime })}
       </IonCol>
@@ -42,7 +41,7 @@ const ForecastTableDateRow: React.FC<ForecastRowProps> = ({ forecastItem }) => {
   );
 };
 
-const ForecastTableRow: React.FC<ForecastRowProps> = ({ forecastItem }) => {
+const ForecastTableRow: React.FC<ForecastRowProps> = ({ forecastItem, visible }) => {
   let windColClass = 'ForecastColGreen';
   if (forecastItem.windSpeed >= 14) {
     windColClass = 'ForecastColYellow';
@@ -76,9 +75,10 @@ const ForecastTableRow: React.FC<ForecastRowProps> = ({ forecastItem }) => {
   }
 
   const leftAlign: string = ' ion-text-begin';
+  const hide: string = visible ? '' : ' hidden';
 
   return (
-    <IonRow className="ForecastRow">
+    <IonRow className={'ForecastRow' + hide}>
       <IonCol size="2">{getTimeString(new Date(forecastItem.dateTime))}</IonCol>
       <IonCol size="3" className={windColClass + leftAlign}>
         {Math.round(forecastItem.windSpeed)} m/s, {Math.round(forecastItem.windDirection)}&deg;
@@ -96,7 +96,7 @@ const ForecastTableRow: React.FC<ForecastRowProps> = ({ forecastItem }) => {
   );
 };
 
-const ForecastTable: React.FC<ForecastTableProps> = ({ forecastItems, page, clear = false, requiresScrolling = false }) => {
+const ForecastTable: React.FC<ForecastTableProps> = ({ forecastItems, page, clear = false }) => {
   const { t } = useTranslation();
   const [startIndex, setStartIndex] = useState<number>(0);
   const pageSize = page ?? 8;
@@ -110,83 +110,68 @@ const ForecastTable: React.FC<ForecastTableProps> = ({ forecastItems, page, clea
     utcDiffStr += ', ' + timezoneOffsetMinutesToString(new Date(forecastItems[endIndex].dateTime));
   }
 
-  let timeoutId: number;
   const showPreviousPage = () => {
     setStartIndex(startIndex >= pageSize ? startIndex - pageSize : 0);
-    //Remove this when a solution is found in future ticket to fix scroll problem
-    timeoutId = window.setTimeout(scroll, 1);
   };
 
   const showNextPage = () => {
     setStartIndex(startIndex + pageSize);
-    //Remove this when a solution is found in future ticket to fix scroll problem
-    timeoutId = window.setTimeout(scroll, 1);
-  };
-
-  const scroll = () => {
-    //Remove this when a solution is found in future ticket to fix scroll problem
-    if (requiresScrolling) {
-      const anchor = document.querySelector('#bottom');
-      anchor?.scrollIntoView({ behavior: 'smooth' });
-    }
-    window.clearTimeout(timeoutId);
   };
 
   const gridClassName = 'ForecastGrid' + ((clear ? ' clear' : '') + ' ion-no-padding');
   return (
-    <>
-      <IonGrid className={gridClassName}>
-        <IonRow className="HeaderRow ion-justify-content-between">
-          <IonCol size="2" className="header">
-            {t('forecastTable.tableHeaders.time')}
-            <br />
-            <span>({utcDiffStr})</span>
-          </IonCol>
-          <IonCol size="3" className="header">
-            {t('forecastTable.tableHeaders.wind')}
-          </IonCol>
-          <IonCol size="2" className="header">
-            {t('forecastTable.tableHeaders.windGust')}
-          </IonCol>
-          <IonCol size="3" className="header">
-            {t('forecastTable.tableHeaders.wave')}
-          </IonCol>
-          <IonCol size="2" className="header">
-            {t('forecastTable.tableHeaders.visibility')}
-          </IonCol>
-        </IonRow>
-        {forecastItems.length > 0 ? (
-          forecastItems.slice(startIndex, startIndex + pageSize).map((item, index, items) => {
-            const showDateRow =
-              (index === 0 && new Date(items[0].dateTime).getDate() === new Date(items[items.length - 1].dateTime).getDate()) ||
-              (index !== 0 && new Date(items[index].dateTime).getDate() !== new Date(items[index - 1].dateTime).getDate());
-            return (
-              <div key={item.dateTime}>
-                {showDateRow && <ForecastTableDateRow forecastItem={item} />}
-                <ForecastTableRow forecastItem={item} />
-              </div>
-            );
-          })
-        ) : (
-          <IonRow>
-            <IonCol>-</IonCol>
-          </IonRow>
-        )}
+    <IonGrid className={gridClassName}>
+      <IonRow className="HeaderRow ion-justify-content-between">
+        <IonCol size="2" className="header">
+          {t('forecastTable.tableHeaders.time')}
+          <br />
+          <span>({utcDiffStr})</span>
+        </IonCol>
+        <IonCol size="3" className="header">
+          {t('forecastTable.tableHeaders.wind')}
+        </IonCol>
+        <IonCol size="2" className="header">
+          {t('forecastTable.tableHeaders.windGust')}
+        </IonCol>
+        <IonCol size="3" className="header">
+          {t('forecastTable.tableHeaders.wave')}
+        </IonCol>
+        <IonCol size="2" className="header">
+          {t('forecastTable.tableHeaders.visibility')}
+        </IonCol>
+      </IonRow>
+      {forecastItems.length > 0 ? (
+        forecastItems.map((item, index, items) => {
+          const isOnThisPage = index >= startIndex && index < startIndex + pageSize;
+          const showDateRow =
+            isOnThisPage &&
+            ((index === startIndex && new Date(item.dateTime).getDate() === new Date(items[startIndex + pageSize - 1].dateTime).getDate()) ||
+              (index !== 0 && new Date(items[index].dateTime).getDate() !== new Date(items[index - 1].dateTime).getDate()));
+          return (
+            <div key={item.dateTime}>
+              {showDateRow && <ForecastTableDateRow forecastItem={item} visible={showDateRow} />}
+              <ForecastTableRow forecastItem={item} visible={isOnThisPage} />
+            </div>
+          );
+        })
+      ) : (
         <IonRow>
-          <IonCol size="6">
-            <button className="ChangePageButton" onClick={showPreviousPage} disabled={startIndex === 0}>
-              {t('forecastTable.previousPage')} {pageSize}h
-            </button>
-          </IonCol>
-          <IonCol size="6">
-            <button className="ChangePageButton ion-float-right" onClick={showNextPage} disabled={startIndex + pageSize >= forecastItems.length}>
-              {t('forecastTable.nextPage')} {pageSize}h
-            </button>
-          </IonCol>
+          <IonCol>-</IonCol>
         </IonRow>
-      </IonGrid>
-      <div id="bottom" />
-    </>
+      )}
+      <IonRow>
+        <IonCol size="6">
+          <button className="ChangePageButton" onClick={showPreviousPage} disabled={startIndex === 0}>
+            {t('forecastTable.previousPage')} {pageSize}h
+          </button>
+        </IonCol>
+        <IonCol size="6">
+          <button className="ChangePageButton ion-float-right" onClick={showNextPage} disabled={startIndex + pageSize >= forecastItems.length}>
+            {t('forecastTable.nextPage')} {pageSize}h
+          </button>
+        </IonCol>
+      </IonRow>
+    </IonGrid>
   );
 };
 

--- a/src/components/content/ForecastContainer.tsx
+++ b/src/components/content/ForecastContainer.tsx
@@ -12,6 +12,7 @@ import './Forecast.css';
 
 type ForecastContentProps = {
   forecast: Feature<Geometry>;
+  multicontainer?: boolean;
 };
 
 export type ForecastProperties = {
@@ -19,7 +20,7 @@ export type ForecastProperties = {
   properties: ForecastFeatureProperties;
 };
 
-const ForecastContainer: React.FC<ForecastContentProps> = ({ forecast }) => {
+const ForecastContainer: React.FC<ForecastContentProps> = ({ forecast, multicontainer = false }) => {
   const { t, i18n } = useTranslation();
   const lang = i18n.resolvedLanguage as Lang;
   const { dataUpdatedAt } = useFeatureData('forecast');
@@ -46,7 +47,7 @@ const ForecastContainer: React.FC<ForecastContentProps> = ({ forecast }) => {
       </IonRow>
       <br />
       <IonRow>
-        <ForecastTable forecastItems={properties.forecastItems} page={12} clear={true} />
+        <ForecastTable forecastItems={properties.forecastItems} page={12} clear={true} multitable={multicontainer} />
       </IonRow>
       <br />
     </IonGrid>

--- a/src/components/content/ForecastContainer.tsx
+++ b/src/components/content/ForecastContainer.tsx
@@ -12,7 +12,6 @@ import './Forecast.css';
 
 type ForecastContentProps = {
   forecast: Feature<Geometry>;
-  requiresScrolling?: boolean;
 };
 
 export type ForecastProperties = {
@@ -20,7 +19,7 @@ export type ForecastProperties = {
   properties: ForecastFeatureProperties;
 };
 
-const ForecastContainer: React.FC<ForecastContentProps> = ({ forecast, requiresScrolling }) => {
+const ForecastContainer: React.FC<ForecastContentProps> = ({ forecast }) => {
   const { t, i18n } = useTranslation();
   const lang = i18n.resolvedLanguage as Lang;
   const { dataUpdatedAt } = useFeatureData('forecast');
@@ -47,7 +46,7 @@ const ForecastContainer: React.FC<ForecastContentProps> = ({ forecast, requiresS
       </IonRow>
       <br />
       <IonRow>
-        <ForecastTable forecastItems={properties.forecastItems} page={12} clear={true} requiresScrolling={requiresScrolling} />
+        <ForecastTable forecastItems={properties.forecastItems} page={12} clear={true} />
       </IonRow>
       <br />
     </IonGrid>

--- a/src/components/content/fairwayCard/FairwayCardContent.tsx
+++ b/src/components/content/fairwayCard/FairwayCardContent.tsx
@@ -355,7 +355,7 @@ export const FairwayCardContent: React.FC<FairwayCardContentProps> = ({
           <div className={getTabClassName(FairwayCardTab.WeatherForecasts)}>
             {forecastsReady && forecasts
               ? forecasts.map((f) => {
-                  return <ForecastContainer forecast={f} key={f.getId()} />;
+                  return <ForecastContainer forecast={f} key={f.getId()} multicontainer={forecasts.length > 1} />;
                 })
               : ''}
           </div>

--- a/src/components/content/fairwayCard/FairwayCardContent.tsx
+++ b/src/components/content/fairwayCard/FairwayCardContent.tsx
@@ -355,7 +355,7 @@ export const FairwayCardContent: React.FC<FairwayCardContentProps> = ({
           <div className={getTabClassName(FairwayCardTab.WeatherForecasts)}>
             {forecastsReady && forecasts
               ? forecasts.map((f) => {
-                  return <ForecastContainer forecast={f} key={f.getId()} requiresScrolling={forecasts.length === 1} />;
+                  return <ForecastContainer forecast={f} key={f.getId()} />;
                 })
               : ''}
           </div>


### PR DESCRIPTION
There was an easy solution to this - to add the array index as a key when creating the rows in the forecast table. However this is highly discouraged as it may lead to incorrect functioning of the React components. The solution is to add all rows and hide those that should not be on the page. This caused problems with multiple forecasts on one page so a hybrid strategy is used separately for 1 table or multiple containers and tables