### PR TITLE
DVK-1709 : Optimised the API calls to the weather forecast. Updated t…

### DIFF
--- a/cdk/lib/lambda/api/weather.ts
+++ b/cdk/lib/lambda/api/weather.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Geometry, Point } from 'geojson';
+import { Geometry, Point, Position } from 'geojson';
 import { log } from '../logger';
 import { roundGeometry } from '../util';
 import { XMLParser } from 'fast-xml-parser';
@@ -78,11 +78,11 @@ const SAARISTOMERI_BBOX = [
   [20.0667, 59.6],
   [22.4667, 60.8],
 ];
-type extraForecastLocation = {
+type ExtraForecastLocation = {
   name: Text;
-  coords: number[];
+  coords: Position;
 };
-const EXTRA_FORECAST_LOCATIONS = [
+const EXTRA_FORECAST_LOCATIONS: ExtraForecastLocation[] = [
   { name: { fi: 'Sundinkari', sv: 'Sundinkari', en: 'Sundinkari' }, coords: [60.786888, 21.325472] },
   {
     name: { fi: 'Jakob Ramsjö säähavaintoasema', sv: 'Jakob Ramsjö säähavaintoasema', en: 'Jakob Ramsjö säähavaintoasema' },
@@ -163,18 +163,26 @@ export async function fetchWeatherObservations(): Promise<Observation[]> {
   });
 }
 
-function getCommonForecastLocations(pilotPoints: PilotPlace[], searchRadius: number = 5): string {
+function getForecastLocations(pilotPoints: PilotPlace[], extraForecastLocations: ExtraForecastLocation[], searchRadius: number = 5): string {
   //Take all pilot places and additional defined locations
   return (
     '&latlons=' +
-    pilotPoints.map((p) => p.geometry.coordinates?.reverse().join() + ':' + searchRadius).join() +
-    ',' +
-    EXTRA_FORECAST_LOCATIONS.map((c) => c.coords.join() + ':' + searchRadius).join()
+    pilotPoints
+      .map((p) => {
+        if (p.geometry.coordinates) {
+          return p.geometry.coordinates[1] + ',' + p.geometry.coordinates[0] + ':' + searchRadius;
+        } else {
+          return null;
+        }
+      })
+      .join() +
+    (extraForecastLocations.length > 0 ? ',' : '') +
+    extraForecastLocations.map((c) => c.coords.join() + ':' + searchRadius).join()
   );
 }
 
 //Map a location to a pilot place to get the id and name based on matching the point
-function mapToPilotPlace(pilotPoints: PilotPlace[], extraLocations: extraForecastLocation[], latlon: string) {
+function mapToPilotPlace(pilotPoints: PilotPlace[], extraLocations: ExtraForecastLocation[], latlon: string) {
   const pilotPlace = pilotPoints.find(
     (p) =>
       p.geometry.coordinates != null &&
@@ -197,10 +205,10 @@ function removeSearchRadius(place: string): string {
 }
 
 function getWaveDirectionAndHeight(geom: Point, measure: WeatherWaveForecastApi) {
-  if (isInBoundingBox(geom, HELSINKI_BBOX)) {
+  if (isInBoundingBox(geom.coordinates, HELSINKI_BBOX)) {
     return { waveDirection: measure.waveDirectionHelsinki ?? measure.waveDirection, waveHeight: measure.waveHeightHelsinki ?? measure.waveHeight };
   }
-  if (isInBoundingBox(geom, SAARISTOMERI_BBOX)) {
+  if (isInBoundingBox(geom.coordinates, SAARISTOMERI_BBOX)) {
     return {
       waveDirection: measure.waveDirectionSaaristomeri ?? measure.waveDirection,
       waveHeight: measure.waveHeightSaaristomeri ?? measure.waveHeight,
@@ -209,24 +217,33 @@ function getWaveDirectionAndHeight(geom: Point, measure: WeatherWaveForecastApi)
   return { waveDirection: measure.waveDirection, waveHeight: measure.waveHeight };
 }
 
-function isInBoundingBox(point: Point, bbox: number[][]) {
+function isInBoundingBox(point: Position, bbox: number[][]) {
   //No need to use OL to do simple bbox check here
-  return (
-    bbox[0][0] <= point.coordinates[0] &&
-    bbox[0][1] <= point.coordinates[1] &&
-    bbox[1][0] >= point.coordinates[0] &&
-    bbox[1][1] >= point.coordinates[1]
-  );
+  return bbox[0][0] <= point[0] && bbox[0][1] <= point[1] && bbox[1][0] >= point[0] && bbox[1][1] >= point[1];
 }
 
-export async function fetchWeatherWaveForecast(
+function isInHelsinki(point: PilotPlace | ExtraForecastLocation) {
+  return isInBoundingBox('geometry' in point ? (point.geometry as Point).coordinates : point.coords, HELSINKI_BBOX);
+}
+
+function isInSaaristomeri(point: PilotPlace | ExtraForecastLocation) {
+  return isInBoundingBox('geometry' in point ? (point.geometry as Point).coordinates : point.coords, SAARISTOMERI_BBOX);
+}
+
+function isNeitherInHelsinkiNorSaaristomeri(point: PilotPlace | ExtraForecastLocation) {
+  return !isInHelsinki(point) && !isInSaaristomeri(point);
+}
+
+function getPath(
   pilotPoints: PilotPlace[],
+  extraForecastLocations: ExtraForecastLocation[],
+  areaFilter: (item: PilotPlace | ExtraForecastLocation) => boolean,
+  includeHelsinki: boolean,
+  includeSaaristomeri: boolean,
   numberTimesteps: number = 48
-): Promise<{
-  forecast: WeatherWaveForecast[];
-  responseTime: any;
-}> {
+): string {
   const searchRadius = 6;
+
   const fields = [
     'place',
     'localtime',
@@ -235,27 +252,44 @@ export async function fetchWeatherWaveForecast(
     'nanmax(FFG-MS:::6:10:1) as windGust',
     'nanmedian(DPW-D:WAM_BALMFC:1061:6:0:1) as waveDirection',
     'nanmax(HWS-M:WAM_BALMFC:1061:6:0:1) as waveHeight',
-    'nanmedian(DPW-D:WAM_HKI:1117:6:0:1) as waveDirectionHelsinki',
-    'nanmax(HWS-M:WAM_HKI:1117:6:0:1) as waveHeightHelsinki',
-    'nanmedian(DPW-D:WAM_BALMFC_ARCH:1119:6:0:1) as waveDirectionSaaristomeri',
-    'nanmax(HWS-M:WAM_BALMFC_ARCH:1119:6:0:1) as waveHeightSaaristomeri',
+    includeHelsinki ? 'nanmedian(DPW-D:WAM_HKI:1117:6:0:1) as waveDirectionHelsinki' : '',
+    includeHelsinki ? 'nanmax(HWS-M:WAM_HKI:1117:6:0:1) as waveHeightHelsinki' : '',
+    includeSaaristomeri ? 'nanmedian(DPW-D:WAM_BALMFC_ARCH:1119:6:0:1) as waveDirectionSaaristomeri' : '',
+    includeSaaristomeri ? 'nanmax(HWS-M:WAM_BALMFC_ARCH:1119:6:0:1) as waveHeightSaaristomeri' : '',
     'nanmedian(MUL{VV2-M:MEPSMTA:1093:6:0:4:0;0.001}) as visibility',
   ];
-
   const responseDetails = '&precision=double&format=json&timeformat=sql';
-
-  const response = await fetchWeatherApiResponse(
+  return (
     'timeseries?param=' +
-      encodeURIComponent(fields.join()) +
-      getCommonForecastLocations(pilotPoints, searchRadius) +
-      responseDetails +
-      '&timesteps=' +
-      numberTimesteps
+    encodeURIComponent(fields.filter((f) => f.length > 0).join()) +
+    getForecastLocations(pilotPoints.filter(areaFilter), extraForecastLocations.filter(areaFilter), searchRadius) +
+    responseDetails +
+    '&timesteps=' +
+    numberTimesteps
   );
-  const responseTime = (response.headers.date ?? Date.now()) as number;
+}
+
+export async function fetchWeatherWaveForecast(pilotPoints: PilotPlace[]): Promise<{
+  forecast: WeatherWaveForecast[];
+  responseTime: any;
+}> {
+  let responseTime;
+  let allResults: WeatherWaveForecastApi[] = [];
+
+  const path1 = getPath(pilotPoints, EXTRA_FORECAST_LOCATIONS, (p) => isNeitherInHelsinkiNorSaaristomeri(p), false, false);
+  const path2 = getPath(pilotPoints, EXTRA_FORECAST_LOCATIONS, (p) => isInSaaristomeri(p), false, true);
+  const path3 = getPath(pilotPoints, EXTRA_FORECAST_LOCATIONS, (p) => isInHelsinki(p), true, false);
+
+  await Promise.all([fetchWeatherApiResponse(path1), fetchWeatherApiResponse(path2), fetchWeatherApiResponse(path3)]).then((values) => {
+    responseTime = (values[0].headers.date ?? Date.now()) as number;
+    values.forEach((v) => {
+      const items = v.data as WeatherWaveForecastApi[];
+      items.forEach((i) => allResults.push(i));
+    });
+  });
 
   const forecast = Object.values(
-    (response.data as WeatherWaveForecastApi[])
+    allResults
       .map((measure) => {
         const latlng = removeSearchRadius(measure.place);
         const geometry = parseGeometry(removeSearchRadius(measure.place));

--- a/cdk/test/__snapshots__/featureloader.test.ts.snap
+++ b/cdk/test/__snapshots__/featureloader.test.ts.snap
@@ -550,33 +550,6 @@ exports[`should get weather and wave forecast from api 1`] = `
     {
       "geometry": {
         "coordinates": [
-          24.928,
-          60.044,
-        ],
-        "type": "Point",
-      },
-      "id": "60.044,24.928",
-      "properties": {
-        "featureType": "forecast",
-        "forecastItems": [
-          {
-            "dateTime": 1730203200000,
-            "visibility": 40,
-            "waveDirection": 233.7,
-            "waveHeight": 0.6,
-            "windDirection": 292,
-            "windGust": 7.8,
-            "windSpeed": 5.1,
-          },
-        ],
-        "name": null,
-        "pilotPlaceId": null,
-      },
-      "type": "Feature",
-    },
-    {
-      "geometry": {
-        "coordinates": [
           21.11,
           60.08,
         ],
@@ -594,6 +567,33 @@ exports[`should get weather and wave forecast from api 1`] = `
             "windDirection": 262,
             "windGust": 8.2,
             "windSpeed": 5.9,
+          },
+        ],
+        "name": null,
+        "pilotPlaceId": null,
+      },
+      "type": "Feature",
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          24.928,
+          60.044,
+        ],
+        "type": "Point",
+      },
+      "id": "60.044,24.928",
+      "properties": {
+        "featureType": "forecast",
+        "forecastItems": [
+          {
+            "dateTime": 1730203200000,
+            "visibility": 40,
+            "waveDirection": 233.7,
+            "waveHeight": 0.6,
+            "windDirection": 292,
+            "windGust": 7.8,
+            "windSpeed": 5.1,
           },
         ],
         "name": null,

--- a/cdk/test/featureloader.test.ts
+++ b/cdk/test/featureloader.test.ts
@@ -410,12 +410,11 @@ const forecast = [
     windGust: 10.3,
     waveDirection: 247.4,
     waveHeight: 0.8,
-    waveDirectionSaaristomeri: null,
-    waveHeightSaaristomeri: null,
-    waveDirectionHelsinki: null,
-    waveHeightHelsinki: null,
     visibility: 40.0,
   },
+];
+
+const forecastHelsinki = [
   {
     place: '60.044,24.928:5',
     localtime: '2024-10-29 12:00:00',
@@ -424,12 +423,13 @@ const forecast = [
     windGust: 7.8,
     waveDirection: 235.8,
     waveHeight: 0.6,
-    waveDirectionSaaristomeri: null,
-    waveHeightSaaristomeri: null,
     waveDirectionHelsinki: 233.7,
     waveHeightHelsinki: 0.6,
     visibility: 40.0,
   },
+];
+
+const forecastSaaristomeri = [
   {
     place: '60.08,21.11:5',
     localtime: '2024-10-29 12:00:00',
@@ -440,8 +440,6 @@ const forecast = [
     waveHeight: 0.3,
     waveDirectionSaaristomeri: 275.7,
     waveHeightSaaristomeri: 0.3,
-    waveDirectionHelsinki: null,
-    waveHeightHelsinki: null,
     visibility: 40.0,
   },
 ];
@@ -502,8 +500,7 @@ const points = {
 
 const traficomN2000MapAreas = {
   type: 'FeatureCollection',
-  features: [
-  ]
+  features: [],
 };
 
 async function parseResponse(body: string): Promise<FeatureCollection> {
@@ -566,9 +563,26 @@ jest.mock('../lib/lambda/api/axios', () => ({
       return buoys;
     }
   },
-  fetchWeatherApiResponse: () => {
+  fetchWeatherApiResponse: (path: string) => {
     if (throwError) {
       throw new Error('Fetching from Weather forecast api failed');
+    }
+    if (path.includes('waveHeightHelsinki')) {
+      return {
+        data: forecastHelsinki,
+        headers: {
+          date: 0,
+        },
+      };
+    }
+
+    if (path.includes('waveHeightSaaristomeri')) {
+      return {
+        data: forecastSaaristomeri,
+        headers: {
+          date: 0,
+        },
+      };
     }
     return {
       data: forecast,


### PR DESCRIPTION
Optimisation is such that it now uses 3 promises and only uses the relevant functions for the calls depending on the location (Saaristomeri, Helsinki, other). Saaristomeri and Helsinki areas also call the general values so they can be used as a fallback value in case the value returned is null.

One problem doing this was that at some point the pilot places list was acted on with the following - .filter => .map => .reverse

The reverse function reverses the original object and seems to affect up the chain to the original array (even though filter should create a new array). Note to self : avoid using "reverse" if possible