### PR TITLE
DVK-1723 - fix missing forecast place names

### DIFF
--- a/cdk/lib/lambda/api/weather.ts
+++ b/cdk/lib/lambda/api/weather.ts
@@ -186,8 +186,10 @@ function mapToPilotPlace(pilotPoints: PilotPlace[], extraLocations: ExtraForecas
   const pilotPlace = pilotPoints.find(
     (p) =>
       p.geometry.coordinates != null &&
-      p.geometry.coordinates[0] === parseFloat(latlon?.split(',')[0]?.trim()) &&
-      p.geometry.coordinates[1] === parseFloat(latlon?.split(',')[1]?.trim())
+      // this was changed to [0] === [1], because for some reason suddenly longitude and latitude changed order??
+      // so there wasn't any names for forecast places
+      p.geometry.coordinates[0] === parseFloat(latlon?.split(',')[1]?.trim()) &&
+      p.geometry.coordinates[1] === parseFloat(latlon?.split(',')[0]?.trim())
   );
   if (pilotPlace == null) {
     const extraLocation = extraLocations.find(


### PR DESCRIPTION
Pilot place names are attached to forecasts in backend. Name for forecast is found when comparing geometry of a pilot place and forecast place. For some reason latitude was compared to longitude and vice versa, so names were not found. It used to work in the same order but no idea why it has changed. Either way it's fixed now.