### PR TITLE
DVK-1713 - Application runs even if background maps doesn't load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -330,11 +330,12 @@ const DvkIonApp: React.FC = () => {
       )}
       {!fetchError && bgFetchError && (
         <IonAlert
+          className="bgAlertModal"
           isOpen={initDone}
           backdropDismiss={true}
-          header={'varo vaaraa'}
-          message={'Ei saatu nyt kyl taustakarttoi sori, tosi pahoillani'}
-          buttons={['OK']}
+          header={t('appInitAlert.bgErrorTitle')}
+          message={t('appInitAlert.bgErrorContent')}
+          buttons={[t('common.continue')]}
         />
       )}
       {!fetchError && <IonAlert isOpen={!initDone} backdropDismiss={false} header={t('appInitAlert.title')} message={t('appInitAlert.content')} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,13 +137,13 @@ const DvkIonApp: React.FC = () => {
   const pilotLayer = usePilotLayer();
   const harborLayer = useHarborLayer();
   const boardLine12Layer = useBoardLine12Layer();
+  const circleLayer = useCircleLayer();
+  /* Start initializing other layers */
   const bgFinlandLayer = useInitStaticDataLayer('finland', 'finland');
   const bgMmlmeriLayer = useInitStaticDataLayer('mml_meri', 'mml_meri');
   const bgMmlmerirantaviivaLayer = useInitStaticDataLayer('mml_meri_rantaviiva', 'mml_meri_rantaviiva');
   const bgMmljarviLayer = useInitStaticDataLayer('mml_jarvi', 'mml_jarvi');
   const bgMmljarvirantaviivaLayer = useInitStaticDataLayer('mml_jarvi_rantaviiva', 'mml_jarvi_rantaviiva');
-  const circleLayer = useCircleLayer();
-  /* Start initializing other layers */
   useDepth12Layer();
   useSpeedLimitLayer();
   useSafetyEquipmentAndFaultLayer();
@@ -183,11 +183,12 @@ const DvkIonApp: React.FC = () => {
   const [percentDone, setPercentDone] = useState(0);
   const [fetchError, setFetchError] = useState(false);
   const [centering, setCentering] = useState(false);
+  const [bgFetchError, setBgFetchError] = useState(false);
 
   const { state } = useDvkContext();
 
   useEffect(() => {
-    const allLayers: DvkLayerState[] = [
+    const mandatoryLayers: DvkLayerState[] = [
       fairwayCardList,
       line12Layer,
       area12Layer,
@@ -196,11 +197,10 @@ const DvkIonApp: React.FC = () => {
       pilotLayer,
       harborLayer,
       boardLine12Layer,
-      bgFinlandLayer,
-      bgMmlmeriLayer,
-      bgMmljarviLayer,
       circleLayer,
     ];
+    const bgLayers: DvkLayerState[] = [bgFinlandLayer, bgMmlmeriLayer, bgMmljarviLayer];
+    const allLayers: DvkLayerState[] = mandatoryLayers.concat(bgLayers);
 
     let percent = 0;
     const resourcePercentage = 1 / allLayers.length;
@@ -211,9 +211,10 @@ const DvkIonApp: React.FC = () => {
 
     setPercentDone(Math.round(percent * 100) / 100);
 
-    setFetchError(allLayers.some((layer) => layer.isError));
+    setFetchError(mandatoryLayers.some((layer) => layer.isError));
+    setBgFetchError(bgLayers.some((layer) => layer.isError));
 
-    setInitDone(allLayers.every((layer) => layer.ready));
+    setInitDone(mandatoryLayers.every((layer) => layer.ready));
   }, [
     fairwayCardList,
     line12Layer,
@@ -326,6 +327,15 @@ const DvkIonApp: React.FC = () => {
       </IonReactRouter>
       {fetchError && (
         <IonAlert isOpen={!initDone} backdropDismiss={false} header={t('appInitAlert.errorTitle')} message={t('appInitAlert.errorContent')} />
+      )}
+      {!fetchError && bgFetchError && (
+        <IonAlert
+          isOpen={initDone}
+          backdropDismiss={true}
+          header={'varo vaaraa'}
+          message={'Ei saatu nyt kyl taustakarttoi sori, tosi pahoillani'}
+          buttons={['OK']}
+        />
       )}
       {!fetchError && <IonAlert isOpen={!initDone} backdropDismiss={false} header={t('appInitAlert.title')} message={t('appInitAlert.content')} />}
     </IonApp>

--- a/src/components/FeatureLoader.tsx
+++ b/src/components/FeatureLoader.tsx
@@ -218,7 +218,7 @@ export function useInitStaticDataLayer(
         layer.set('status', 'loading');
         (async () => {
           get(featureDataId).then(async (data) => {
-            if (data) {
+            if (data && featureLayerId == 'balticsea') {
               initLayer(data);
             } else {
               await axios

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -341,7 +341,9 @@
     "title": "Initializing app",
     "content": "Please wait",
     "errorTitle": "Loading error",
-    "errorContent": "Error occurred when loading data. Please try again later."
+    "bgErrorTitle": "[en] Taustakarttojen latausvirhe",
+    "errorContent": "Error occurred when loading data. Please try again later.",
+    "bgErrorContent": "[en] Taustakarttojen latauksessa tapahtui virhe. Voit jatkaa sovelluksen käyttöä, mutta taustakartta-aineisto voi olla puutteellista."
   },
   "popup": {
     "common": {
@@ -580,7 +582,8 @@
     "filter": "Select filter...",
     "sortOldToNew": "Oldest first",
     "sortNewToOld": "Newest first",
-    "submit": "Submit"
+    "submit": "Submit",
+    "continue": "Continue"
   },
   "tileLoadWarning": {
     "vectorTileError": "Unexpected error in loading of vector chart data. A raster chart is temporarily in use."

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -341,7 +341,9 @@
     "title": "Sovellusta alustetaan",
     "content": "Ole hyvä ja odota hetki",
     "errorTitle": "Latausvirhe",
-    "errorContent": "Tietojen latauksessa tapahtui virhe. Ole hyvä ja yritä uudelleen."
+    "bgErrorTitle": "Taustakarttojen latausvirhe",
+    "errorContent": "Tietojen latauksessa tapahtui virhe. Ole hyvä ja yritä uudelleen.",
+    "bgErrorContent": "Taustakarttojen latauksessa tapahtui virhe. Voit jatkaa sovelluksen käyttöä, mutta taustakartta-aineisto voi olla puutteellista."
   },
   "popup": {
     "common": {
@@ -581,7 +583,8 @@
     "filter": "Valitse suodatin...",
     "sortOldToNew": "Vanhin ensin",
     "sortNewToOld": "Uusin ensin",
-    "submit": "Lähetä"
+    "submit": "Lähetä",
+    "continue": "Jatka"
   },
   "tileLoadWarning": {
     "vectorTileError": "Yllättävä virhe kartan vektoritiilien latauksessa. Kartta käyttää väliaikaisesti rasteritaustakarttaa."

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -341,7 +341,9 @@
     "title": "Appen initialiseras",
     "content": "Var vänlig och vänta",
     "errorTitle": "Nedladdningsfel",
-    "errorContent": "Uppstod ett fel i nedladdningen,  var vänlig och försök igen."
+    "bgErrorTitle": "[sv] Taustakarttojen latausvirhe",
+    "errorContent": "Uppstod ett fel i nedladdningen,  var vänlig och försök igen.",
+    "bgErrorContent": "[sv] Taustakarttojen latauksessa tapahtui virhe. Voit jatkaa sovelluksen käyttöä, mutta taustakartta-aineisto voi olla puutteellista."
   },
   "popup": {
     "common": {
@@ -581,7 +583,8 @@
     "filter": "Välj filter...",
     "sortOldToNew": "Äldst först",
     "sortNewToOld": "Nyaste först",
-    "submit": "Skicka"
+    "submit": "Skicka",
+    "continue": "[sv] Jatka"
   },
   "tileLoadWarning": {
     "vectorTileError": "Fel i laddning av kartans vektortegel. Karta använder tillfälligt bakgrundskarta i rasterformat."

--- a/src/theme/dvk.css
+++ b/src/theme/dvk.css
@@ -332,3 +332,7 @@ ion-range::part(bar) {
 ion-range::part(bar-active) {
   background: var(--ion-color-secondary)
 }
+
+.bgAlertModal .alert-message.sc-ion-alert-md {
+  padding-bottom: 0px; /* Add space below the message */
+}


### PR DESCRIPTION
Separated error fetching to mandatory and background layers. If there's error loading background layers, only alert modal will pop up. Initializing is done when there's no error on mandatory layers. 

Tested the behaviour by returning this object from useInitStaticDataLayer function (FeatureLoader.tsx)


  if (featureLayerId.includes('finland')) {
    return { ready: false, dataUpdatedAt: Date.now(), isPaused: false, errorUpdatedAt: Date.now(), isError: true };
  }
