### PR TITLE
DVK-1711 - S3 cache fetching and saving for prohibition areas and pilot places

### DIFF
--- a/cdk/lib/lambda/api/featureloader-handler.ts
+++ b/cdk/lib/lambda/api/featureloader-handler.ts
@@ -7,9 +7,9 @@ import HarborDBModel from '../db/harborDBModel';
 import { parseDateTimes } from './pooki';
 import { fetchBuoys, fetchMareoGraphs, fetchWeatherObservations, fetchWeatherWaveForecast } from './weather';
 import { fetchN2000MapAreas, fetchPilotPoints, fetchProhibitionAreas, fetchVTSLines, fetchVTSPoints } from './traficom';
-import { getFeatureCacheControlHeaders } from '../graphql/cache';
+import { cacheResponse, getFeatureCacheControlHeaders, getFromCache } from '../graphql/cache';
 import { fetchVATUByApi, fetchMarineWarnings } from './axios';
-import { getNumberValue, invertDegrees, roundDecimals, toBase64Response } from '../util';
+import { getNumberValue, invertDegrees, mapPilotFeatures, mapProhibitionAreaFeatures, roundDecimals, toBase64Response } from '../util';
 import {
   AlueFeature,
   AlueFeatureCollection,
@@ -27,6 +27,7 @@ import {
   TurvalaiteVikatiedotFeatureCollection,
 } from './apiModels';
 import { booleanWithin as turf_booleanWithin } from '@turf/boolean-within';
+import { ProhibitionArea } from '../../../graphql/generated';
 
 interface FeaturesWithMaxFetchTime {
   featureArray: Feature<Geometry, GeoJsonProperties>[];
@@ -72,17 +73,28 @@ async function addHarborFeatures(features: FeaturesWithMaxFetchTime) {
 }
 
 async function addPilotFeatures(features: FeaturesWithMaxFetchTime) {
-  const pilotPlaces = await fetchPilotPoints();
-  for (const place of pilotPlaces) {
-    features.featureArray.push({
-      type: 'Feature',
-      geometry: place.geometry as Geometry,
-      id: place.id,
-      properties: {
-        featureType: 'pilot',
-        name: place.name,
-      },
-    });
+  const pilotCacheKey = 'pilotplaces';
+  
+  try {
+    // pilot points are not saved to s3 like prohibition areas are, since pilot places are
+    // saved in many other cases (fairwayCard-handler, fairwayCards-handler, saveFairwayCard-handler)
+    log.info(`Fetching ${pilotCacheKey} from traficom api`)
+    const data = await fetchPilotPoints();
+    const pilotPlaces = mapPilotFeatures(data) as Feature[];
+    features.featureArray.push(...pilotPlaces);
+    log.debug('Prohibition areas: %d', pilotPlaces.length);
+  } catch (e) {
+    log.error(`Fetching ${pilotCacheKey} from traficom api unsuccesful, retrieving from cache...`);
+    log.error(e);
+    log.error('mitä');
+    const response = await getFromCache(pilotCacheKey);
+    if (response.data) {
+      const data = JSON.parse(response.data);
+      const pilotPlaces = mapPilotFeatures(data) as Feature[];
+      features.featureArray.push(...pilotPlaces);
+    }
+
+    log.info(`Fetching ${pilotCacheKey} from cache succesful!`)
   }
 }
 
@@ -181,9 +193,34 @@ async function addAreaFeatures(features: FeaturesWithMaxFetchTime, event: ALBEve
 }
 
 async function addProhibitionAreaFeatures(features: FeaturesWithMaxFetchTime) {
-  const areas = await fetchProhibitionAreas();
-  log.debug('prohibition areas: %d', areas.length);
-  features.featureArray.push(...areas);
+  const prohibitionCacheKey = 'prohibitionareas';
+
+  try {
+    log.info(`Fetching ${prohibitionCacheKey} from traficom api`)
+    const areas = await fetchProhibitionAreas();
+    if (areas) {
+      log.info('Saving response to S3');
+      await cacheResponse(prohibitionCacheKey, areas);
+      log.info('Saving successful!');
+      log.debug('Prohibition areas: %d', areas.length);
+      features.featureArray.push(...areas);
+    } else {
+      throw new Error('Fetching error');
+    }
+  } catch (e) {
+    log.error(`Fetching ${prohibitionCacheKey} from traficom api unsuccesful, retrieving from cache...`);
+    log.error(e);
+
+    const response = await getFromCache(prohibitionCacheKey);
+    if (response.data) {
+      const areas = JSON.parse(response.data) as Feature[];
+
+      log.debug('prohibition areas: %d', areas.length);
+      features.featureArray.push(...areas);
+
+      log.info(`Fetching ${prohibitionCacheKey} from cache succesful!`)
+    }
+  }
 }
 
 async function addRestrictionAreaFeatures(features: FeaturesWithMaxFetchTime, event: ALBEvent) {
@@ -651,7 +688,11 @@ export const handler = async (event: ALBEvent): Promise<ALBResult> => {
           },
         };
       }
+      console.log('COLLECTION ON TÄÄLLÄ');
+      console.log(collection);
       base64Response = await toBase64Response(collection);
+      console.log('BASE64RESPONSE');
+      console.log(base64Response);
     }
   } catch (e) {
     base64Response = undefined;

--- a/cdk/lib/lambda/api/featureloader-handler.ts
+++ b/cdk/lib/lambda/api/featureloader-handler.ts
@@ -688,11 +688,7 @@ export const handler = async (event: ALBEvent): Promise<ALBResult> => {
           },
         };
       }
-      console.log('COLLECTION ON TÄÄLLÄ');
-      console.log(collection);
       base64Response = await toBase64Response(collection);
-      console.log('BASE64RESPONSE');
-      console.log(base64Response);
     }
   } catch (e) {
     base64Response = undefined;

--- a/cdk/lib/lambda/api/traficom.ts
+++ b/cdk/lib/lambda/api/traficom.ts
@@ -1,5 +1,5 @@
 import { Feature, FeatureCollection, GeoJsonProperties, Geometry, MultiPolygon, Point, Polygon } from 'geojson';
-import { roundGeometry } from '../util';
+import { mapProhibitionAreaFeatures, roundGeometry } from '../util';
 import { PilotPlace } from '../../../graphql/generated';
 import { fetchTraficomApi } from './axios';
 import { union as turf_union } from '@turf/union';
@@ -63,30 +63,7 @@ export async function fetchProhibitionAreas(): Promise<Feature<Geometry, GeoJson
   const path =
     'trafiaineistot/inspirepalvelu/avoin/wfs?request=GetFeature&service=WFS&version=1.1.0&outputFormat=application/json&typeName=avoin:kohtaamis_ja_ohittamiskieltoalueet';
   const data = await fetchTraficomApi<FeatureCollection>(path);
-  return data.features.map((row) => {
-    return {
-      type: 'Feature',
-      id: row.properties?.ALUENRO,
-      geometry: row.geometry,
-      properties: {
-        featureType: 'specialarea15',
-        typeCode: 15,
-        type: row.properties?.RAJOITE_TYYPPI,
-        vtsArea: row.properties?.VTS_ALUE,
-        extraInfo: {
-          fi: row.properties?.LISATIETO?.trim(),
-          sv: row.properties?.LISATIETO_SV?.trim(),
-        },
-        fairway: {
-          fairwayId: row.properties?.JNRO,
-          name: {
-            fi: row.properties?.VAYLA_NIMI,
-            sv: row.properties?.VAYLA_NIMI_SV,
-          },
-        },
-      },
-    };
-  });
+  return mapProhibitionAreaFeatures(data.features);
 }
 
 export async function fetchN2000MapAreas(): Promise<Polygon | MultiPolygon | undefined> {

--- a/cdk/lib/lambda/graphql/cache.ts
+++ b/cdk/lib/lambda/graphql/cache.ts
@@ -48,6 +48,10 @@ const MARINEWARNING_CACHE = {
 
 export const FEATURE_CACHE_DURATION = 7200; // 2 hours
 
+export const TRAFICOM_CACHE_DURATION = 86400 * 3 // 3 days
+
+const traficomS3Keys = ['prohibitionareas', 'pilotplaces'];
+
 function getCacheBucketName() {
   return `featurecache-${getEnvironment()}`;
 }
@@ -57,6 +61,8 @@ export function getFeatureCacheDuration(key: string) {
     return AIS_LOCATION_CACHE.MAX_AGE;
   } else if (key === 'aisvessels') {
     return AIS_VESSEL_CACHE.MAX_AGE;
+  } else if (traficomS3Keys.includes(key)) {
+    return TRAFICOM_CACHE_DURATION;
   } else {
     return FEATURE_CACHE_DURATION;
   }

--- a/cdk/lib/lambda/util.ts
+++ b/cdk/lib/lambda/util.ts
@@ -1,4 +1,4 @@
-import { FeatureCollection, Geometry, Position } from 'geojson';
+import { Feature, FeatureCollection, GeoJsonProperties, Geometry, Position } from 'geojson';
 import { gzip } from 'zlib';
 import { log } from './logger';
 import { CacheResponse, cacheResponse, getAisCacheControlHeaders } from './graphql/cache';
@@ -7,7 +7,7 @@ import { Vessel } from './api/apiModels';
 import { getExpires, getHeaders } from './environment';
 import FairwayCardDBModel from './db/fairwayCardDBModel';
 import HarborDBModel from './db/harborDBModel';
-import { Operation, Status } from '../../graphql/generated';
+import { Operation, PilotPlace, Status } from '../../graphql/generated';
 import { PutCommand, QueryCommand, QueryCommandInput } from '@aws-sdk/lib-dynamodb';
 import { getDynamoDBDocumentClient } from './db/dynamoClient';
 
@@ -448,4 +448,45 @@ export async function getPreviousVersion(tableName: string, id: string, latestVe
     console.log(error);
     return undefined;
   }
+}
+
+export function mapProhibitionAreaFeatures(data: Feature<Geometry, GeoJsonProperties>[]) {
+  return data.map((row) => {
+    return {
+      type: 'Feature',
+      id: row.properties?.ALUENRO,
+      geometry: row.geometry,
+      properties: {
+        featureType: 'specialarea15',
+        typeCode: 15,
+        type: row.properties?.RAJOITE_TYYPPI,
+        vtsArea: row.properties?.VTS_ALUE,
+        extraInfo: {
+          fi: row.properties?.LISATIETO?.trim(),
+          sv: row.properties?.LISATIETO_SV?.trim(),
+        },
+        fairway: {
+          fairwayId: row.properties?.JNRO,
+          name: {
+            fi: row.properties?.VAYLA_NIMI,
+            sv: row.properties?.VAYLA_NIMI_SV,
+          },
+        },
+      },
+    } as Feature;
+  });
+}
+
+export function mapPilotFeatures(pilotPlaces: PilotPlace[]) {
+  return pilotPlaces.map((place) => {
+    return {
+      type: 'Feature',
+      geometry: place.geometry as Geometry,
+      id: place.id,
+      properties: {
+        featureType: 'pilot',
+        name: place.name,
+      },
+    };
+  });
 }


### PR DESCRIPTION
- Prohibition areas added to S3 cache
- Prohibition areas are saved whenever cloudfront cache does not provide data (approx. every 2 hours).
- Pilot places are not saved with same logic, since saving happens in quite many different occasions (fairwayCard-handler, fairwayCards-handler, saveFairwayCard-handler)
- Data expires in 3 days