### PR TITLE
fix/DVK-1703 - When wrapper collapsible closed and opened, don't re-render map

### DIFF
--- a/admin/src/theme/dvk.css
+++ b/admin/src/theme/dvk.css
@@ -925,7 +925,7 @@ ion-grid.formGrid ion-col:last-of-type {
   max-height: 0;
   overflow: hidden;
   /* This is mostly because of playwright tests, since max-height counts as visible when testing "expect().toBeHidden()"*/
-  display: none;
+  visibility: hidden;
 }
 
 /* Footer */


### PR DESCRIPTION
When style is set display: none and then set back to visible, dvkMap is re-rendered. Because of getFittingPadding() makes map zoomed in to close. In css file instead of display:none, visibility:hidden is used, so component is not re-rendered and playwright still pass.